### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM docker:25.0.3-dind
 RUN apk add --no-cache python3 py3-pip bash
-RUN mkdir -p /app
 WORKDIR /app
-COPY launch.sh /app/launch.sh
-RUN chmod +x /app/launch.sh
+COPY launch.sh launch.sh
+RUN chmod +x launch.sh
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
-CMD [ "/app/launch.sh" ]
+CMD [ "launch.sh" ]


### PR DESCRIPTION
The `WORKDIR` instruction sets the working directory for any `RUN`, `CMD`, `ENTRYPOINT`, `COPY` and `ADD` instructions that follow it in the Dockerfile. If the `WORKDIR` doesn't exist, it will be created even if it's not used in any subsequent Dockerfile instruction.